### PR TITLE
Loop through all arguments for maximum yesage

### DIFF
--- a/yes.c
+++ b/yes.c
@@ -1,6 +1,5 @@
 /*
     OCKcore - "yes" utility
-
     Copyright (c) 2022 Griffin
     Distributed under the terms of the ISC Licence.
 */
@@ -13,7 +12,8 @@ int main(int argc, char **argv) {
             puts("y");
     else
         while(1)
-            puts(argv[1]);
+            for (int i=1; i<argc; i++)
+                puts(argv[i]);
 
     fflush(stdout);
     return 0;


### PR DESCRIPTION
This change adds the ability for the OCKcore Yes utility to loop through every argument, for maximum yesage.

![image](https://user-images.githubusercontent.com/52890399/182688855-eeb6dc74-4b97-4a59-a3c7-933eaefcb0d5.png)
